### PR TITLE
Fix typo in the API docs page for ECMAS

### DIFF
--- a/doc/api.html
+++ b/doc/api.html
@@ -44,7 +44,7 @@
 <pre><code class="highlight language-html">&lt;input type="checkbox" data-toggle="toggle" data-on="Enabled" data-off="Disabled"&gt;
 &lt;input type="checkbox" id="toggle-two"&gt;
 &lt;script&gt;
-    doctument.querySelector('#toggle-two').bootstrapToggle({
+    document.querySelector('#toggle-two').bootstrapToggle({
         on: 'Enabled',
         off: 'Disabled'
     });

--- a/v3.X.X/doc/api.html
+++ b/v3.X.X/doc/api.html
@@ -44,7 +44,7 @@
 <pre><code class="highlight language-html">&lt;input type="checkbox" data-toggle="toggle" data-on="Enabled" data-off="Disabled"&gt;
 &lt;input type="checkbox" id="toggle-two"&gt;
 &lt;script&gt;
-    doctument.querySelector('#toggle-two').bootstrapToggle({
+    document.querySelector('#toggle-two').bootstrapToggle({
         on: 'Enabled',
         off: 'Disabled'
     });


### PR DESCRIPTION
Should I should have put the PR against the `gh-pages-develop` branch instead of `gh-pages` or is this fine?
I can do the other if so.