### PR TITLE
Fix touch not working

### DIFF
--- a/js/bootstrap5-toggle.jquery.js
+++ b/js/bootstrap5-toggle.jquery.js
@@ -272,10 +272,7 @@ function sanitize(text) {
     }
 
     // 9: Add listeners
-    this.$toggle.on("touchstart", (e) => {
-      toggleActionPerformed(e, this);
-    });
-    this.$toggle.on("click", (e) => {
+    this.$toggle.on("pointerdown", (e) => {
       toggleActionPerformed(e, this);
     });
     this.$toggle.on("keypress", (e) => {


### PR DESCRIPTION
Issue #191 is caused by binding both, click and touchstart events, so on mobile, if you just tap the toggle, both get triggered.
By binding only to the pointerdown event, you handle both, mobile and desktop in one event, and no longer double-trigger on mobile.