### PR TITLE
docs: remove 'simply' from docs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-# For most projects, this workflow file will not need changing; you simply need
+# For most projects, this workflow file will not need changing; you need
 # to commit it to your repository.
 #
 # You may wish to alter this file to override the set of languages analyzed,

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ yarn add bootstrap5-toggle@5.1.2
 
 ## Initialize With HTML
 
-Simply add `data-toggle="toggle"` to automatically convert a plain checkbox into a bootstrap 5 toggle.
+Add `data-toggle="toggle"` to automatically convert a plain checkbox into a bootstrap 5 toggle.
 
 ```html
 <input id="chkToggle" type="checkbox" data-toggle="toggle" />

--- a/README.template.md
+++ b/README.template.md
@@ -117,7 +117,7 @@ yarn add bootstrap5-toggle@#version#
 
 ## Initialize With HTML
 
-Simply add `data-toggle="toggle"` to automatically convert a plain checkbox into a bootstrap 5 toggle.
+Add `data-toggle="toggle"` to automatically convert a plain checkbox into a bootstrap 5 toggle.
 
 ```html
 <input id="chkToggle" type="checkbox" data-toggle="toggle" />


### PR DESCRIPTION
This PR removes the word 'simply' from the docs as it adds no information and can be considered condescending

Closes #208 