### PR TITLE
fix(dom): correct toggle sizing when initialized in hidden containers

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/src/test/setup/dom.setup.ts"],
   globals: {
     "ts-jest": {
       tsconfig: "tsconfig.test.json"

--- a/src/main/ts/core/DOMBuilder.ts
+++ b/src/main/ts/core/DOMBuilder.ts
@@ -19,8 +19,13 @@ export class DOMBuilder {
   private toggleOff: HTMLElement;
   private toggleHandle: HTMLElement;
 
+  private isBuilt: boolean = false;
+  private lastState: ToggleState;
+  private resizeObserver?: ResizeObserver;
+
   /**
    * Initializes a new instance of the DOMBuilder class.
+   * This renders the toggle if the parent element is visible, otherwise defers rendering until it becomes visible.
    * @param checkbox HTMLInputElement element representing the toggle.
    * @param options ToggleOptions object containing options for the toggle.
    * @param state ToggleState object containing the initial state of the toggle.
@@ -30,6 +35,7 @@ export class DOMBuilder {
     options: ToggleOptions,
     state: ToggleState
   ) {
+    this.lastState = state;
     this.onStyle = `btn-${options.onstyle}`;
     this.offStyle = `btn-${options.offstyle}`;
     this.name = options.name;
@@ -56,9 +62,47 @@ export class DOMBuilder {
     this.toggleHandle = this.createToggleHandle();
     this.toggleGroup = this.createToggleGroup();
     this.toggle = document.createElement("div");
-    this.renderToggle(options);
 
-    this.render(state);
+    if(this.isVisible()){
+      this.renderToggle(options);
+      this.render(state);
+    }else{
+      this.deferRender(options);
+    }
+  }
+
+  /**
+   * Checks if the parent element of the checkbox is visible.
+   * A parent element is considered visible if its `offsetWidth` and `offsetHeight` are greater than `0`.
+   * @returns boolean indicating whether the parent element is visible or not.
+   */
+  private isVisible(): boolean {
+    const parent = this.checkbox.parentElement;
+    return !!parent && parent.offsetWidth > 0 && parent.offsetHeight > 0;
+  }
+
+  /**
+   * Defer rendering the toggle until the parent element is visible.
+   * It does this by observing the parent element's bounding rectangle and only rendering the toggle once the width and height of the bounding rectangle are greater than 0.
+   * @param options ToggleOptions object containing options for the toggle.
+   */
+  private deferRender(options: ToggleOptions): void {
+    this.resizeObserver = new ResizeObserver(entries => {
+      if (this.isBuilt) {
+        this.resizeObserver!.disconnect();
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.contentRect.width > 0 && entry.contentRect.height > 0) {
+          this.renderToggle(options);
+          this.render(this.lastState);
+          this.isBuilt = true;
+          this.resizeObserver!.disconnect();
+          return;
+        }
+      }
+    });
+    this.resizeObserver.observe(this.checkbox.parentElement!);
   }
 
   /**
@@ -119,6 +163,8 @@ export class DOMBuilder {
     this.toggle.appendChild(this.toggleGroup);
 
     this.handleToggleSize(width, height);
+
+    this.isBuilt = true;
   }
 
   /**
@@ -229,7 +275,8 @@ export class DOMBuilder {
   }
 
   /**
-   * Renders the toggle element based on the provided state.
+   * Renders the toggle element based on the provided state if the toggle is already built.
+   * This method should be called whenever the state of the toggle changes.
    * @param {ToggleState} state The state of the toggle element.
    */
   public render(state: ToggleState): void {
@@ -239,6 +286,9 @@ export class DOMBuilder {
       "off",
       "indeterminate"
     );
+    this.lastState = state;
+    
+    if (!this.isBuilt) return;
 
     switch (state.value) {
       case ToggleStateValue.ON:
@@ -318,10 +368,16 @@ export class DOMBuilder {
 
   /**
    * Destroys the toggle by removing the toggle element from the DOM and
-   *inserting the original checkbox element back into its original position.
+   * inserting the original checkbox element back into its original position.
+   * Also disconnects the ResizeObserver if it was used.
    */
   public destroy(): void {
     this.toggle.parentNode?.insertBefore(this.checkbox, this.toggle);
     this.toggle.parentNode?.removeChild(this.toggle);
+
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
+
+    this.isBuilt = false;
   }
 }

--- a/src/test/setup/dom.setup.ts
+++ b/src/test/setup/dom.setup.ts
@@ -1,0 +1,52 @@
+/**
+ * Setup HTML layout measurements for testing environment.
+ */
+function defineOffsetProperties(width: number, height: number) {
+ Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    get() {
+      return width;
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get() {
+      return height;
+    },
+  });
+}
+(global as any).__dom_setup_setVisible = () => defineOffsetProperties(100, 30);
+(global as any).__dom_setup_setHidden = () => defineOffsetProperties(0, 0);
+
+beforeEach(() => {
+  (global as any).__dom_setup_setVisible();
+});
+
+/**
+ * Mock ResizeObserver for testing purposes.
+ */
+let resizeCallback: ResizeObserverCallback;
+class ResizeObserverMock {
+  constructor(cb: ResizeObserverCallback) {
+    resizeCallback = cb;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserverMock;
+
+(global as any).__dom_setup_triggerResize = (
+  width = 100,
+  height = 30
+) => {
+  resizeCallback(
+    [
+      {
+        contentRect: { width, height },
+      } as ResizeObserverEntry,
+    ],
+    {} as ResizeObserver
+  );
+};

--- a/src/test/ts/BootstrapToggle.test.ts
+++ b/src/test/ts/BootstrapToggle.test.ts
@@ -1,4 +1,5 @@
 import { Toggle } from "../../main/ts/BootstrapToggle";
+import { DOMBuilder } from "../../main/ts/core/DOMBuilder";
 import { ToggleActionType } from "../../main/ts/core/StateReducer.types";
 
 /* =========================
@@ -324,7 +325,7 @@ describe("Toggle", () => {
       toggle.rerender();
 
       expect(destroyMock).toHaveBeenCalled();
-      expect((input as any).bootstrapToggle).toHaveBeenCalled();
+      expect(DOMBuilder).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/test/ts/core/DOMBuilder.test.ts
+++ b/src/test/ts/core/DOMBuilder.test.ts
@@ -2,7 +2,7 @@ import { DOMBuilder } from "../../../main/ts/core/DOMBuilder";
 import {
   ToggleStateStatus,
   ToggleStateValue,
-  ToggleState
+  ToggleState,
 } from "../../../main/ts/core/StateReducer.types";
 import { ToggleOptions } from "../../../main/ts/core/OptionResolver.types";
 
@@ -29,7 +29,7 @@ const BASE_OPTIONS: ToggleOptions = {
   height: null,
   tabindex: 0,
   tristate: false,
-  name: "myToggle"
+  name: "myToggle",
 };
 
 function state(
@@ -42,7 +42,7 @@ function state(
     value,
     status,
     checked,
-    indeterminate
+    indeterminate,
   };
 }
 
@@ -66,6 +66,21 @@ describe("DOMBuilder", () => {
     expect(toggle!.querySelector(".toggle-on")).not.toBeNull();
     expect(toggle!.querySelector(".toggle-off")).not.toBeNull();
     expect(toggle!.querySelector(".toggle-handle")).not.toBeNull();
+  });
+
+  it("defers render when parent not visible", () => {
+    (global as any).__dom_setup_setHidden();
+    const checkbox = createCheckbox();
+
+    new DOMBuilder(
+      checkbox,
+      BASE_OPTIONS,
+      state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED)
+    );
+    expect(document.querySelector(".toggle")).toBeNull();
+    (global as any).__dom_setup_setVisible();
+    (global as any).__dom_setup_triggerResize(120, 40);
+    expect(document.querySelector(".toggle")).not.toBeNull();
   });
 
   it("renders ON state", () => {
@@ -182,7 +197,7 @@ describe("DOMBuilder", () => {
       {
         ...BASE_OPTIONS,
         width: "120px",
-        height: "40px"
+        height: "40px",
       },
       state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED)
     );


### PR DESCRIPTION
Use ResizeObserver to defer DOM rendering until the parent element
becomes visible, ensuring correct width and height calculation when
toggles are initialized inside hidden containers (e.g. tabs, accordions).

Fixes #231
Fixes #214