### PR TITLE
fix(events): prevent unintended toggle on scroll and right-click

### DIFF
--- a/src/main/ts/BootstrapToggle.ts
+++ b/src/main/ts/BootstrapToggle.ts
@@ -10,6 +10,9 @@ export class Toggle {
   private options: ToggleOptions;
   private stateReducer: StateReducer;
   private domBuilder: DOMBuilder;
+
+  private pointer: { x: number; y: number } | null = null;
+  private readonly SCROLL_THRESHOLD = 10;
   private eventsBound = false;
 
   /**
@@ -80,11 +83,9 @@ export class Toggle {
    * other event listeners from being triggered.
    */
   private bindPointerEventListener() {
-    this.domBuilder.root.addEventListener(
-      "pointerdown",
-      this.handlePointerEvent,
-      { passive: true }
-    );
+    this.domBuilder.root.addEventListener("pointerdown", this.onPointerDown, {
+      passive: true,
+    });
   }
 
   /**
@@ -95,14 +96,92 @@ export class Toggle {
    * @returns void
    */
   private unbindPointerEventListener() {
-    this.domBuilder.root.removeEventListener(
-      "pointerdown",
-      this.handlePointerEvent
-    );
+    this.domBuilder.root.removeEventListener("pointerdown", this.onPointerDown);
   }
 
-  private handlePointerEvent = (e: PointerEvent) => {
-    this.apply(ToggleActionType.NEXT);
+  /**
+   * Handles pointer down events by initiating the toggle action and setting up
+   * listeners for pointer movement, release, and cancellation.
+   *
+   * The method early exits if:
+   * - the pointer event is not a primary mouse button click
+   * - the toggle cannot be interacted with (`disabled` or `readonly`)
+   * @param e The PointerEvent object representing the pointer down event.
+   */
+  private onPointerDown = (e: PointerEvent) => {
+    if (e.pointerType === "mouse" && e.button !== 0) return;
+    if (!this.stateReducer.canInteract()) return;
+
+    this.pointer = { x: e.clientX, y: e.clientY };
+    this.domBuilder.root.addEventListener("pointermove", this.onPointerMove, {
+      passive: true,
+    });
+    this.domBuilder.root.addEventListener("pointerup", this.onPointerUp, {
+      passive: true,
+    });
+    this.domBuilder.root.addEventListener(
+      "pointercancel",
+      this.onPointerCancel,
+      { passive: true }
+    );
+  };
+
+  /**
+   * Handles pointer move events by checking the distance moved from the initial pointer down position.
+   * If the pointer has moved beyond a certain threshold, the pointer interaction is cancelled.
+   *
+   * Allows dragging within the width of the toggle but cancels if vertical movement exceeds the scroll threshold.
+   * @param e The PointerEvent object representing the pointer move event.
+   */
+  private onPointerMove = (e: PointerEvent) => {
+    const dx = Math.abs(e.clientX - this.pointer!.x);
+    const dy = Math.abs(e.clientY - this.pointer!.y);
+
+    if (dy > this.SCROLL_THRESHOLD || dx > this.domBuilder.root.offsetWidth) {
+      this.onPointerCancel();
+    }
+  };
+
+  /**
+   * Handles pointer up events by determining if the pointer interaction
+   * should trigger a toggle action based on the distance moved.
+   *
+   * If the pointer has moved beyond a certain threshold, the pointer interaction is cancelled.
+   * Allows dragging within the width of the toggle but cancels if vertical movement exceeds the scroll threshold.
+   * Finally, it cleans up by calling the pointer cancel handler.
+   * 
+   * If the pointer event is not a primary mouse button click, the interaction is cancelled.
+   * @param e The PointerEvent object representing the pointer up event.
+   */
+  private onPointerUp = (e: PointerEvent) => {
+    if (e.pointerType === "mouse" && e.button !== 0) {
+      this.onPointerCancel();
+      return;
+    }
+    const dx = Math.abs(e.clientX - this.pointer!.x);
+    const dy = Math.abs(e.clientY - this.pointer!.y);
+
+    if (dy <= this.SCROLL_THRESHOLD && dx <= this.domBuilder.root.offsetWidth) {
+      this.apply(ToggleActionType.NEXT);
+    }
+
+    this.onPointerCancel();
+  };
+
+  /**
+   * Cleans up pointer event listeners after a pointer interaction is completed or cancelled.
+   *
+   * This method removes the `pointermove`, `pointerup`, and `pointercancel` event listeners
+   * from the root element of the toggle.
+   * However, `pointerdown` listener remains active for future interactions.
+   */
+  private onPointerCancel = () => {
+    this.domBuilder.root.removeEventListener("pointermove", this.onPointerMove);
+    this.domBuilder.root.removeEventListener("pointerup", this.onPointerUp);
+    this.domBuilder.root.removeEventListener(
+      "pointercancel",
+      this.onPointerCancel
+    );
   };
 
   /**

--- a/src/main/ts/core/StateReducer.ts
+++ b/src/main/ts/core/StateReducer.ts
@@ -55,6 +55,14 @@ export class StateReducer {
   }
 
   /**
+   * Determines whether the toggle is enabled and can be interacted with.
+   * @returns True if the toggle is enabled and can be interacted with, false otherwise.
+   */
+  public canInteract(): boolean {
+    return this.state.status === ToggleStateStatus.ENABLED;
+  }
+
+  /**
    * Synchronizes the internal state of the toggle with the provided HTMLInputElement.
    * This method is useful when you need to update the internal state of the toggle
    * manually, such as when the toggle is updated programmatically.
@@ -80,7 +88,7 @@ export class StateReducer {
   public do(action: ToggleActionType): boolean {
     switch (action) {
       case ToggleActionType.ON:
-        if (this.state.status != ToggleStateStatus.ENABLED) return false;
+        if (!this.canInteract()) return false;
         if (this.state.value === ToggleStateValue.ON) return false;
         this.state = {
           ...this.state,
@@ -90,7 +98,7 @@ export class StateReducer {
         };
         return true;
       case ToggleActionType.OFF:
-         if (this.state.status != ToggleStateStatus.ENABLED) return false;
+         if (!this.canInteract()) return false;
         if (this.state.value === ToggleStateValue.OFF) return false;
         this.state = {
           ...this.state,
@@ -100,12 +108,12 @@ export class StateReducer {
         };
         return true;
       case ToggleActionType.TOGGLE:
-        if (this.state.status != ToggleStateStatus.ENABLED) return false;
+        if (!this.canInteract()) return false;
         if (this.state.value === ToggleStateValue.ON) return this.do(ToggleActionType.OFF);
         if (this.state.value === ToggleStateValue.OFF) return this.do(ToggleActionType.ON);
         return false;
       case ToggleActionType.INDETERMINATE:
-         if (this.state.status != ToggleStateStatus.ENABLED) return false;
+         if (!this.canInteract()) return false;
         if (this.state.value === ToggleStateValue.INDETERMINATE) return false;
         this.state = {
           ...this.state,
@@ -114,7 +122,7 @@ export class StateReducer {
         };
         return true;
       case ToggleActionType.DETERMINATE:
-         if (this.state.status != ToggleStateStatus.ENABLED) return false;
+         if (!this.canInteract()) return false;
         if (this.state.value != ToggleStateValue.INDETERMINATE) return false;
         this.state = {
           ...this.state,
@@ -125,7 +133,7 @@ export class StateReducer {
         };
         return true;
       case ToggleActionType.NEXT:
-         if (this.state.status != ToggleStateStatus.ENABLED) return false;
+         if (!this.canInteract()) return false;
         if (this.isTristate) {
           if (
             this.state.value === ToggleStateValue.ON ||
@@ -164,7 +172,7 @@ export class StateReducer {
         }
         return true;
       case ToggleActionType.READONLY:
-        if(this.state.status != ToggleStateStatus.ENABLED) return false;
+        if(!this.canInteract()) return false;
         this.state = {
           ...this.state,
           status: ToggleStateStatus.READONLY


### PR DESCRIPTION
- Use dynamic pointer listeners (pointerdown/up/move/cancel) to track gestures
- Cancel toggle if pointer moves beyond scroll/drag thresholds
- Apply toggle only on pointerup for tap/drag interactions
- Ignore right-clicks and other non-left mouse buttons

Fixes #213
Fixes #153
Fixes #187