### PR TITLE
fix(options): support css units for width and height options

### DIFF
--- a/src/main/ts/core/OptionResolver.ts
+++ b/src/main/ts/core/OptionResolver.ts
@@ -1,4 +1,4 @@
-import { sanitize } from "./Tools";
+import { isNumeric, sanitize } from "./Tools";
 import {
     UserOptions,
     ToggleOptions,
@@ -183,8 +183,8 @@ export class OptionResolver {
             ),
         };
 
-        if(options.width && parseFloat(options.width)) options.width = `${options.width}px`;
-        if(options.height && parseFloat(options.height)) options.height = `${options.height}px`;
+        if(options.width && isNumeric(options.width)) options.width = `${options.width}px`;
+        if(options.height && isNumeric(options.height)) options.height = `${options.height}px`;
 
         DeprecationConfig.handle(options, element, userOptions);
 

--- a/src/main/ts/core/Tools.ts
+++ b/src/main/ts/core/Tools.ts
@@ -12,3 +12,19 @@ export function sanitize(text: string | null): string | null {
 
     return text.replace(/[&<>"'/]/g, (m) => map[m]);
 }
+
+/**
+ * Checks if the given string is a valid numeric value.
+ * 
+ * A valid numeric value is a `string` that starts with an optional plus or minus sign,
+ * followed by one or more digits, optionally followed by a decimal point and
+ * one or more digits.
+ * 
+ * Examples of valid numeric values include "123", "-123", "+123.45", "-123.45", etc.
+ * Examples of invalid numeric values include "abc", "123abc", "123.abc", etc.
+ * @param {string} value The string to check for being a valid numeric value.
+ * @returns {boolean} `true` if the string contains a valid numeric value, `false` otherwise.
+ */
+export function isNumeric(value: string): boolean {
+    return /^[+-]?\d+(\.\d+)?$/.test(value.trim());
+}

--- a/src/main/ts/core/Tools.ts
+++ b/src/main/ts/core/Tools.ts
@@ -22,9 +22,9 @@ export function sanitize(text: string | null): string | null {
  * 
  * Examples of valid numeric values include "123", "-123", "+123.45", "-123.45", etc.
  * Examples of invalid numeric values include "abc", "123abc", "123.abc", etc.
- * @param {string} value The string to check for being a valid numeric value.
+ * @param {string | number} value The string or number to check for being a valid numeric value.
  * @returns {boolean} `true` if the string contains a valid numeric value, `false` otherwise.
  */
-export function isNumeric(value: string): boolean {
-    return /^[+-]?\d+(\.\d+)?$/.test(value.trim());
+export function isNumeric(value: string | number): boolean {
+    return /^[+-]?\d+(\.\d+)?$/.test(value.toString().trim());
 }

--- a/src/test/ts/core/OptionResolver.test.ts
+++ b/src/test/ts/core/OptionResolver.test.ts
@@ -73,4 +73,69 @@ describe("OptionResolver", () => {
         expect(options.onlabel).toBe("UserOn");
         expect(options.offlabel).toBe("UserOff");
     });
+
+    describe("width and height options", () => {
+        it("resolve numeric values as pixel unit", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "5",
+                height: "5",
+            });
+            expect(options.width).toBe("5px");
+            expect(options.height).toBe("5px");
+        });
+
+        it("support px unit", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "5px",
+                height: "5px",
+            });
+            expect(options.width).toBe("5px");
+            expect(options.height).toBe("5px");
+        });
+
+        it("support rem unit", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "5rem",
+                height: "5rem",
+            });
+            expect(options.width).toBe("5rem");
+            expect(options.height).toBe("5rem");
+        });
+
+        it("support em unit", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "5em",
+                height: "5em",
+            });
+            expect(options.width).toBe("5em");
+            expect(options.height).toBe("5em");
+        });
+
+        it("support % unit", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "50%",
+                height: "50%",
+            });
+            expect(options.width).toBe("50%");
+            expect(options.height).toBe("50%");
+        });
+
+        it("support viewport unit", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "5vw",
+                height: "5vh",
+            });
+            expect(options.width).toBe("5vw");
+            expect(options.height).toBe("5vh");
+        });
+
+        it("support auto", () => {
+            const options = OptionResolver.resolve(element as HTMLInputElement, {
+                width: "auto",
+                height: "auto",
+            });
+            expect(options.width).toBe("auto");
+            expect(options.height).toBe("auto");
+        });
+    });
 });

--- a/src/test/ts/core/Tools.test.ts
+++ b/src/test/ts/core/Tools.test.ts
@@ -1,4 +1,4 @@
-import { sanitize } from "../../../main/ts/core/Tools";
+import { isNumeric, sanitize } from "../../../main/ts/core/Tools";
 
 describe("sanitize", () => {
     it("returns null when input is null", () => {
@@ -47,5 +47,22 @@ describe("sanitize", () => {
 
     it("escapes characters appearing multiple times", () => {
         expect(sanitize("&&&&")).toBe("&amp;&amp;&amp;&amp;");
+    });
+});
+
+describe("isNumeric(value: string): boolean",()=>{
+    it("returns true for valid numeric values", () => {
+        expect(isNumeric("123")).toBe(true);
+        expect(isNumeric("-123")).toBe(true);
+        expect(isNumeric("+123")).toBe(true);
+        expect(isNumeric("123.45")).toBe(true);
+        expect(isNumeric("-123.45")).toBe(true);
+        expect(isNumeric("+123.45")).toBe(true);
+    });
+
+    it("returns false for invalid numeric values", () => {
+        expect(isNumeric("abc")).toBe(false);
+        expect(isNumeric("123abc")).toBe(false);
+        expect(isNumeric("123.abc")).toBe(false);
     });
 });

--- a/src/test/ts/core/Tools.test.ts
+++ b/src/test/ts/core/Tools.test.ts
@@ -52,6 +52,8 @@ describe("sanitize", () => {
 
 describe("isNumeric(value: string): boolean",()=>{
     it("returns true for valid numeric values", () => {
+        expect(isNumeric(123)).toBe(true);
+        expect(isNumeric(-123)).toBe(true);
         expect(isNumeric("123")).toBe(true);
         expect(isNumeric("-123")).toBe(true);
         expect(isNumeric("+123")).toBe(true);


### PR DESCRIPTION
Previously, width and height values were always suffixed with "px" when
they contained a numeric value. This caused invalid CSS values when
explicit units such as rem, em, %, vw or vh were provided (e.g. "5rempx").

This change introduces a numeric-only check to ensure that "px" is only
appended to values without an explicit CSS unit, while preserving
user-defined units and keywords like "auto".

Additional unit tests were added to cover numeric values, common CSS
units and edge cases.

FIXES #242