### PR TITLE
feat(core): add full ARIA accessibility support to BootstrapToggle

### DIFF
--- a/src/main/ts/BootstrapToggle.ts
+++ b/src/main/ts/BootstrapToggle.ts
@@ -185,35 +185,35 @@ export class Toggle {
     };
 
     /**
-   * Binds a keypress event listener to the root element of the toggle.
-   * The event listener is responsible for handling keypress events
-   * and triggering the toggle's state change when a keypress event occurs.
+   * Binds a keydown event listener to the root element of the toggle.
+   * The event listener is responsible for handling keydown events
+   * and triggering the toggle's state change when a keydown event occurs.
    * The event listener is bound with the passive option, which means that it will not block
    * other event listeners from being triggered.
    */
     private bindKeyboardEventListener() {
         this.domBuilder.root.addEventListener(
-            "keypress",
+            "keydown",
             this.handlerKeyboardEvent,
             { passive: true }
         );
     }
 
     /**
-   * Unbinds the keypress event listener from the root element of the toggle.
-   * This method is responsible for unbinding the keypress event listener that was
+   * Unbinds the keydown event listener from the root element of the toggle.
+   * This method is responsible for unbinding the keydown event listener that was
    * previously bound by the bindKeyboardEventListener method.
    * If the event listener is not bound (i.e. this.eventsBound is false), this method does nothing.
    * @returns void
    */
     private unbindKeyboardEventListener() {
         this.domBuilder.root.removeEventListener(
-            "keypress",
+            "keydown",
             this.handlerKeyboardEvent
         );
     }
     private readonly handlerKeyboardEvent = (e: KeyboardEvent) => {
-        if (e.key == " ") {
+        if (e.key === " " || e.key === "Enter") {
             this.apply(ToggleActionType.NEXT);
         }
     };

--- a/src/main/ts/core/DOMBuilder.ts
+++ b/src/main/ts/core/DOMBuilder.ts
@@ -1,4 +1,4 @@
-import { ToggleOptions, ToggleSize } from "./OptionResolver.types";
+import { AriaToggleOptions, ToggleOptions, ToggleSize } from "./OptionResolver.types";
 import {
     ToggleState,
     ToggleStateStatus,
@@ -151,16 +151,22 @@ export class DOMBuilder {
         width,
         height,
         tabindex,
+        aria
     }: ToggleOptions): void {
         this.toggle.className= `toggle btn ${this.sizeClass} ${style}`;
         this.toggle.dataset.toggle =  "toggle";
         this.toggle.tabIndex = tabindex;
-        this.toggle.role = "button";
+        this.toggle.role = "switch";
 
+        this.checkbox.tabIndex = -1;
+        if (this.invCheckbox) this.invCheckbox.tabIndex = -1;
+        
         this.checkbox.parentElement?.insertBefore(this.toggle, this.checkbox);
         this.toggle.appendChild(this.checkbox);
         if (this.invCheckbox) this.toggle.appendChild(this.invCheckbox);
         this.toggle.appendChild(this.toggleGroup);
+
+        this.handleLabels(aria);
 
         this.handleToggleSize(width, height);
 
@@ -281,6 +287,27 @@ export class DOMBuilder {
     }
 
     /**
+     * Handles the aria-labelledby and aria-label attributes of the toggle element.
+     * If the checkbox element has a labels property and the length of the labels property is greater than 0,
+     * the aria-labelledby attribute of the toggle element is set to the id of the labels elements.
+     * Otherwise, the aria-label attribute of the toggle element is set to the label property of the ariaOpts object.
+     * @param {AriaToggleOptions} ariaOpts - The object containing the label property to be used for the aria-label attribute.
+     */
+    private handleLabels(ariaOpts: AriaToggleOptions){
+        if (this.checkbox.labels?.length) {
+            const ids = Array.from(this.checkbox.labels)
+                .map(l => l.id)
+                .filter(Boolean);
+
+            if (ids.length) {
+                this.toggle.setAttribute("aria-labelledby", ids.join(" "));
+            }
+        } else{
+            this.toggle.setAttribute("aria-label", ariaOpts.label);
+        }
+    }
+
+    /**
    * Renders the toggle element based on the provided state if the toggle is already built.
    * This method should be called whenever the state of the toggle changes.
    * @param {ToggleState} state The state of the toggle element.
@@ -293,16 +320,15 @@ export class DOMBuilder {
         this.updateToggleByValue(state);
         this.updateToggleByChecked(state);
         this.updateToggleByState(state);
+        this.updateAria(state);
     }
 
-    /*************  ✨ Windsurf Command ⭐  *************/
     /**
      * Updates the class of the toggle element based on the provided state.
      * Removes any existing on/off/indeterminate classes and adds the appropriate class based on the state.
      * If the state is indeterminate, adds the 'indeterminate' class and either the on or off class based on the checked attribute.
      * @param {ToggleState} state The state of the toggle element.
      */
-    /*******  9e620de0-7e60-44a0-b26d-be36099794af  *******/
     private updateToggleByValue(state: ToggleState) {
         this.toggle.classList.remove(
             this.onStyle,
@@ -418,6 +444,31 @@ export class DOMBuilder {
         }
     }
 
+    /**
+     * Updates the aria attributes of the toggle element based on the provided state.
+     * Sets aria-checked to "mixed" if the state is indeterminate, otherwise sets it to the string representation of the state's checked attribute.
+     * Sets aria-disabled to the string representation of whether the state's status is disabled.
+     * Sets aria-readonly to the string representation of whether the state's status is readonly.
+     * @param {ToggleState} state The state of the toggle element.
+     */
+    private updateAria(state: ToggleState) {
+        if (state.indeterminate) {
+            this.toggle.setAttribute("aria-checked", "mixed");
+        } else {
+            this.toggle.setAttribute("aria-checked", String(state.checked));
+        }
+
+        this.toggle.setAttribute(
+            "aria-disabled",
+            String(state.status === ToggleStateStatus.DISABLED)
+        );
+
+        this.toggle.setAttribute(
+            "aria-readonly",
+            String(state.status === ToggleStateStatus.READONLY)
+        );
+    }
+    
     /**
    * Returns the root element of the toggle, which is the container of all toggle elements.
    * @returns {HTMLElement} The root element of the toggle.

--- a/src/main/ts/core/OptionResolver.ts
+++ b/src/main/ts/core/OptionResolver.ts
@@ -31,6 +31,7 @@ export class OptionResolver {
         tabindex: 0,
         tristate: false,
         name: null,
+        aria:{label: "Toggle",},
     };
 
     /**
@@ -188,6 +189,14 @@ export class OptionResolver {
                 userOptions.name,
                 this.DEFAULT.name
             ),
+            aria:{
+                label: this.getAttrOrDefault(
+                    element,
+                    "aria-label",
+                    userOptions.aria?.label,
+                    this.DEFAULT.aria.label
+                ),
+            }
         };
 
         if(options.width && isNumeric(options.width)) options.width = `${options.width}px`;

--- a/src/main/ts/core/OptionResolver.types.ts
+++ b/src/main/ts/core/OptionResolver.types.ts
@@ -14,7 +14,12 @@ export interface ToggleOptions {
   tabindex: number
   tristate: boolean
   name: string | null
+  aria:AriaToggleOptions
 }
+
+export type AriaToggleOptions = {
+    label: string
+};
 
 export type UserOptions =
  Partial<ToggleOptions> & {

--- a/src/test/ts/BootstrapToggle.test.ts
+++ b/src/test/ts/BootstrapToggle.test.ts
@@ -108,7 +108,7 @@ describe("Toggle", () => {
                 expect.any(Object)
             );
             expect(addEventListenerSpyDiv).toHaveBeenCalledWith(
-                "keypress",
+                "keydown",
                 expect.any(Function),
                 expect.any(Object)
             );
@@ -274,9 +274,17 @@ describe("Toggle", () => {
             root = (DOMBuilder as any).mock.results[0].value.root;
         });
 
-        it("toggles on space keypress", () => {
+        it("toggles on space keydown", () => {
             root.dispatchEvent(
-                new KeyboardEvent("keypress", { key: " " })
+                new KeyboardEvent("keydown", { key: " " })
+            );
+
+            expect(doMock).toHaveBeenCalledWith(ToggleActionType.NEXT);
+        });
+
+        it("toggles on Enter keydown", () => {
+            root.dispatchEvent(
+                new KeyboardEvent("keydown", { key: "Enter" })
             );
 
             expect(doMock).toHaveBeenCalledWith(ToggleActionType.NEXT);
@@ -284,7 +292,7 @@ describe("Toggle", () => {
 
         it("ignores other keys", () => {
             root.dispatchEvent(
-                new KeyboardEvent("keypress", { key: "Enter" })
+                new KeyboardEvent("keydown", { key: "Ctrl" })
             );
 
             expect(doMock).not.toHaveBeenCalled();
@@ -494,7 +502,7 @@ describe("Toggle", () => {
                 expect.any(Function)
             );
             expect(removeEventListenerSpyDiv).toHaveBeenCalledWith(
-                "keypress",
+                "keydown",
                 expect.any(Function)
             );
 

--- a/src/test/ts/core/DOMBuilder.test.ts
+++ b/src/test/ts/core/DOMBuilder.test.ts
@@ -32,6 +32,7 @@ const BASE_OPTIONS: ToggleOptions = {
     tabindex: 0,
     tristate: false,
     name: "myToggle",
+    aria: {label: "Toggle"},
 };
 
 function state(
@@ -207,5 +208,186 @@ describe("DOMBuilder", () => {
         const toggle = document.querySelector(".toggle") as HTMLElement;
         expect(toggle.style.width).toBe("120px");
         expect(toggle.style.height).toBe("40px");
+    });
+
+    describe("ARIA accessibility", () => {
+        it("sets role='switch' on toggle root", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("role")).toBe("switch");
+        });
+
+        it("sets aria-label from options", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                {
+                    ...BASE_OPTIONS,
+                    aria: { label: "Email notifications" },
+                },
+                state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-label")).toBe("Email notifications");
+        });
+
+        it("sets aria-checked='true' when ON", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(ToggleStateValue.ON, ToggleStateStatus.ENABLED, true)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-checked")).toBe("true");
+        });
+
+        it("sets aria-checked='false' when OFF", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED, false)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-checked")).toBe("false");
+        });
+
+        it("sets aria-checked='mixed' when INDETERMINATE", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(
+                    ToggleStateValue.INDETERMINATE,
+                    ToggleStateStatus.ENABLED,
+                    false,
+                    true
+                )
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-checked")).toBe("mixed");
+        });
+
+        it("sets aria-disabled when disabled", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(ToggleStateValue.OFF, ToggleStateStatus.DISABLED)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-disabled")).toBe("true");
+            expect(toggle.getAttribute("aria-readonly")).toBe("false");
+        });
+
+        it("sets aria-readonly when readonly", () => {
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(ToggleStateValue.OFF, ToggleStateStatus.READONLY)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-readonly")).toBe("true");
+            expect(toggle.getAttribute("aria-disabled")).toBe("false");
+        });
+
+        it("updates ARIA attributes when state changes", () => {
+            const checkbox = createCheckbox();
+
+            const builder = new DOMBuilder(
+                checkbox,
+                BASE_OPTIONS,
+                state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED, false)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+
+            // OFF (INITIAL STATE)
+
+            // ON
+            builder.render(
+                state(ToggleStateValue.ON, ToggleStateStatus.ENABLED, true)
+            );
+            expect(toggle.getAttribute("aria-checked")).toBe("true");
+            expect(toggle.getAttribute("aria-disabled")).toBe("false");
+            expect(toggle.getAttribute("aria-readonly")).toBe("false");
+
+            // INDETERMINATE
+            builder.render(
+                state(ToggleStateValue.INDETERMINATE, ToggleStateStatus.ENABLED, false, true)
+            );
+            expect(toggle.getAttribute("aria-checked")).toBe("mixed");
+            expect(toggle.getAttribute("aria-disabled")).toBe("false");
+            expect(toggle.getAttribute("aria-readonly")).toBe("false");
+
+            // OFF
+            builder.render(
+                state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED, false)
+            );
+            expect(toggle.getAttribute("aria-checked")).toBe("false");
+            expect(toggle.getAttribute("aria-disabled")).toBe("false");
+            expect(toggle.getAttribute("aria-readonly")).toBe("false"); 
+
+            // DISABLED
+            builder.render(
+                state(ToggleStateValue.OFF, ToggleStateStatus.DISABLED, false)
+            );
+            expect(toggle.getAttribute("aria-checked")).toBe("false");
+            expect(toggle.getAttribute("aria-disabled")).toBe("true");
+            expect(toggle.getAttribute("aria-readonly")).toBe("false");
+
+            // READONLY
+            builder.render(
+                state(ToggleStateValue.ON, ToggleStateStatus.READONLY, true)
+            );
+            expect(toggle.getAttribute("aria-checked")).toBe("true");
+            expect(toggle.getAttribute("aria-disabled")).toBe("false");
+            expect(toggle.getAttribute("aria-readonly")).toBe("true");
+        });
+
+
+        it("uses associated <label> via aria-labelledby when present", () => {
+            const label = document.createElement("label");
+            label.id = "toggle-label";
+            label.htmlFor = "test";
+            label.textContent = "Dark mode";
+
+            document.body.appendChild(label);
+
+            const checkbox = createCheckbox();
+
+            const _ = new DOMBuilder(
+                checkbox,
+                {
+                    ...BASE_OPTIONS
+                },
+                state(ToggleStateValue.OFF, ToggleStateStatus.ENABLED)
+            );
+
+            const toggle = document.querySelector(".toggle")!;
+            expect(toggle.getAttribute("aria-labelledby")).toBe("toggle-label");
+            expect(toggle.hasAttribute("aria-label")).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
Enhances the BootstrapToggle component with full ARIA accessibility, making it
usable with screen readers and other assistive technologies.

Key changes:

- Added role="switch" to the toggle root element.
- Introduced aria-label support from options, falling back to <label> via aria-labelledby.
- Implemented dynamic aria-checked updates for ON, OFF, and INDETERMINATE states.
- Added aria-disabled and aria-readonly attributes reflecting toggle status.
- Updated keyboard handling to trigger toggle on Space and Enter keys.

Ensures the toggle component meets accessibility best practices and improves
compatibility with assistive devices.

Implements #232

### Change Summary
- [X] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
This PR adds full ARIA accessibility support to the BootstrapToggle component,
including role, aria-label, aria-checked, aria-disabled, and aria-readonly attributes.
Keyboard interactions now trigger toggles on both Space and Enter keys.

Related issue: #232

### Test Coverage
- [X] Added tests
- [X] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
- [X] Documentation updated


### Additional Notes
This feature improves accessibility compliance and ensures the toggle works
correctly with screen readers and other assistive technologies.
ARIA-related options and keyboard behavior are now documented in the code.
---

## Pull Request Checklist
- [X] Code adheres to the project's coding style guide.
- [X] All tests are passing.
- [X] The pull request description is complete.
- [X] Documentation is updated if needed.
