### PR TITLE
fix(toggle): intercept input properties and restore descriptors on de…

### DIFF
--- a/src/main/ts/BootstrapToggle.ts
+++ b/src/main/ts/BootstrapToggle.ts
@@ -14,6 +14,8 @@ export class Toggle {
     private pointer: { x: number; y: number } | null = null;
     private readonly SCROLL_THRESHOLD = 10;
     private eventsBound = false;
+    private suppressExternalSync  = false;
+    private originalDescriptors = new Map<string, PropertyDescriptor>();
 
     /**
    * Initializes a new instance of the BootstrapToggle class.
@@ -33,9 +35,70 @@ export class Toggle {
         );
 
         this.bindEventListeners();
+        this.interceptInputProperties();
 
         this.element.bsToggle = this;
     }
+    
+    /**
+     * Intercepts the following input properties to detect external changes:
+     * - checked
+     * - disabled
+     * - readonly
+     * - indeterminate
+     * This method is used to detect changes made to the input element directly,
+     * rather than through the BootstrapToggle API. It is used to maintain the
+     * state of the toggle in cases where the user changes the input element
+     * directly, rather than through the API.
+     * @returns void
+     */
+    private interceptInputProperties() {
+        const props = ["checked", "disabled", "readOnly", "indeterminate"] as const;
+
+        props.forEach((prop) => {
+            const descriptor = Object.getOwnPropertyDescriptor(
+                Object.getPrototypeOf(this.element),
+                prop
+            );
+
+            if (!descriptor || !descriptor.set) return;
+            
+            this.originalDescriptors.set(prop, descriptor);
+
+            Object.defineProperty(this.element, prop, {
+                configurable: true,
+                get: () => descriptor.get!.call(this.element),
+                set: (value) => {
+                    descriptor.set!.call(this.element, value);
+                    if (this.suppressExternalSync ) return;
+                    this.onExternalChange();
+                },
+            });
+        });
+    }
+
+    /**
+     * Restores the original input properties of the toggle element.
+     * This method is used to restore the original descriptors of the input properties
+     * which were intercepted by the BootstrapToggle to detect external changes.
+     * @returns void
+     */
+    private restoreInputProperties() {
+        this.originalDescriptors.forEach((descriptor, prop) => {
+            Object.defineProperty(this.element, prop, descriptor);
+        });
+
+        this.originalDescriptors.clear();
+    }
+
+    /**
+     * Handles the change event of the input element of the toggle.
+     * This event listener is responsible for detecting when the input element
+     * of the toggle changes its state and triggering the update method to keep the toggle in sync.
+     */
+    private readonly onExternalChange = () => {
+        this.update(true);
+    };
 
     /**
    * Binds event listeners to the toggle element.
@@ -50,6 +113,7 @@ export class Toggle {
    */
     private bindEventListeners() {
         if (this.eventsBound) return;
+        this.bindFormResetListener();
         this.bindPointerEventListener();
         this.bindKeyboardEventListener();
         this.bindLabelEventListener();
@@ -69,11 +133,28 @@ export class Toggle {
    */
     private unbindEventListeners() {
         if (!this.eventsBound) return;
+        this.unbindFormResetListener();
         this.unbindPointerEventListener();
         this.unbindKeyboardEventListener();
         this.unbindLabelEventListener();
         this.eventsBound = false;
     }
+
+    private bindFormResetListener() {
+        const form = this.element.form;
+        if (!form) return;
+        form.addEventListener("reset", this.onFormReset);
+    }
+
+    private unbindFormResetListener() {
+        const form = this.element.form;
+        if (!form) return;
+        form.removeEventListener("reset", this.onFormReset);
+    }
+
+    private readonly onFormReset = () => {
+        setTimeout(() => this.onExternalChange(), 0);
+    };
 
     /**
    * Binds a pointerdown event listener to the root element of the toggle.
@@ -268,9 +349,13 @@ export class Toggle {
    * @param silent A boolean indicating whether to trigger the change event after applying the action.
    */
     private apply(action: ToggleActionType, silent = false) {
-        if (this.stateReducer.do(action)) {
+        if (!this.stateReducer.do(action)) return;
+        this.suppressExternalSync  = true;
+        try {
             this.domBuilder.render(this.stateReducer.get());
             if (!silent) this.trigger();
+        } finally {
+            this.suppressExternalSync  = false;
         }
     }
 
@@ -357,9 +442,14 @@ export class Toggle {
    * @param {boolean} silent A boolean indicating whether to trigger the change event after synchronizing the toggle state.
    */
     update(silent: boolean) {
-        this.stateReducer.sync(this.element);
-        this.domBuilder.render(this.stateReducer.get());
-        if (!silent) this.trigger();
+        this.suppressExternalSync  = true;
+        try {
+            this.stateReducer.sync(this.element);
+            this.domBuilder.render(this.stateReducer.get());
+            if (!silent) this.trigger();
+        } finally {
+            this.suppressExternalSync  = false;
+        }
     }
 
     /**
@@ -378,6 +468,7 @@ export class Toggle {
    *After calling this method, the toggle element will be removed from the DOM and all event listeners will be unbound.
    */
     destroy() {
+        this.restoreInputProperties();
         this.unbindEventListeners();
         this.domBuilder.destroy();
         delete this.element.bsToggle;

--- a/src/main/ts/BootstrapToggle.ts
+++ b/src/main/ts/BootstrapToggle.ts
@@ -15,7 +15,7 @@ export class Toggle {
     private readonly SCROLL_THRESHOLD = 10;
     private eventsBound = false;
     private suppressExternalSync  = false;
-    private originalDescriptors = new Map<string, PropertyDescriptor>();
+    private readonly originalDescriptors = new Map<string, PropertyDescriptor>();
 
     /**
    * Initializes a new instance of the BootstrapToggle class.
@@ -61,7 +61,7 @@ export class Toggle {
                 prop
             );
 
-            if (!descriptor || !descriptor.set) return;
+            if (!descriptor?.set) return;
             
             this.originalDescriptors.set(prop, descriptor);
 

--- a/src/test/ts/BootstrapToggle.test.ts
+++ b/src/test/ts/BootstrapToggle.test.ts
@@ -124,6 +124,35 @@ describe("Toggle", () => {
         });
     });
 
+    describe("interceptInputProperties()", () => {
+        it("reacts to checked property change", () => {
+            const toggle = new Toggle(input, {});
+            const spy = jest.spyOn(toggle as any, "onExternalChange");
+
+            input.checked = true;
+
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it("reacts to disabled property change", () => {
+            const toggle = new Toggle(input, {});
+            const spy = jest.spyOn(toggle as any, "onExternalChange");
+
+            input.disabled = true;
+
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it("does not throw when setting same value", () => {
+            new Toggle(input, {});
+
+            expect(() => {
+                input.checked = false;
+            }).not.toThrow();
+        });
+    });
+
+
     describe("Pointer interactions", () => {
         let root: HTMLElement;
 
@@ -310,6 +339,30 @@ describe("Toggle", () => {
         });
     });
 
+    describe("form reset handling", () => {
+        it("syncs after form reset", () => {
+            jest.useFakeTimers();
+
+            const form = document.createElement("form");
+            form.appendChild(input);
+            document.body.appendChild(form);
+
+            const toggle = new Toggle(input, {});
+            const spy = jest.spyOn(toggle as any, "onExternalChange");
+
+            form.reset();
+
+            expect(spy).not.toHaveBeenCalled();
+
+            jest.runAllTimers();
+
+            expect(spy).toHaveBeenCalled();
+
+            jest.useRealTimers();
+        });
+    });
+
+
 
     describe("apply(action: ToggleActionType, silent = false)", () => {
         it("calls StateReducer.do and DOMBuilder.render", () => {
@@ -339,6 +392,15 @@ describe("Toggle", () => {
             input.addEventListener("change", spy);
 
             (toggle as any).apply(ToggleActionType.TOGGLE, true);
+
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it("guard against sync loops:does not react to internal apply-triggered input change", () => {
+            const toggle = new Toggle(input, {});
+            const spy = jest.spyOn(toggle as any, "onExternalChange");
+
+            (toggle as any).apply(ToggleActionType.TOGGLE);
 
             expect(spy).not.toHaveBeenCalled();
         });
@@ -469,12 +531,24 @@ describe("Toggle", () => {
             expect(destroyMock).toHaveBeenCalled();
             expect((input as any).bsToggle).toBeUndefined();
         });
+        it("restores native input descriptors allowing reinitialization", () => {
+            const toggle1 = new Toggle(input, {});
+            toggle1.destroy();
 
+            expect(() => {
+                new Toggle(input, {});
+            }).not.toThrow();
+        });
         it("unbind events listeners", () => {
             input.id = "test-toggle";
+
             const label = document.createElement("label");
             label.setAttribute("for", "test-toggle");
-            document.body.appendChild(label);
+
+            const form = document.createElement("form");
+            form.appendChild(input);
+            form.appendChild(label);
+            document.body.appendChild(form);
 
             const removeEventListenerSpyDiv = jest.spyOn(
                 HTMLDivElement.prototype,
@@ -483,6 +557,11 @@ describe("Toggle", () => {
 
             const removeEventListenerSpyLabel = jest.spyOn(
                 HTMLLabelElement.prototype,
+                "removeEventListener"
+            );
+
+            const removeEventListenerSpyForm = jest.spyOn(
+                HTMLFormElement.prototype,
                 "removeEventListener"
             );
 
@@ -503,8 +582,14 @@ describe("Toggle", () => {
                 expect.any(Function)
             );
 
+            expect(removeEventListenerSpyForm).toHaveBeenCalledWith(
+                "reset",
+                expect.any(Function)
+            );
+
             removeEventListenerSpyDiv.mockRestore();
             removeEventListenerSpyLabel.mockRestore();
+            removeEventListenerSpyForm.mockRestore();
         });
     });
 

--- a/src/test/ts/BootstrapToggle.test.ts
+++ b/src/test/ts/BootstrapToggle.test.ts
@@ -144,7 +144,7 @@ describe("Toggle", () => {
         });
 
         it("does not throw when setting same value", () => {
-            new Toggle(input, {});
+            const _ = new Toggle(input, {});
 
             expect(() => {
                 input.checked = false;
@@ -536,7 +536,7 @@ describe("Toggle", () => {
             toggle1.destroy();
 
             expect(() => {
-                new Toggle(input, {});
+                const _ = new Toggle(input, {});
             }).not.toThrow();
         });
         it("unbind events listeners", () => {


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [x] Bug Fix #261
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
- Fixed input property interception to prevent infinite loops and rerender errors.
- Added suppression for internal apply/update-triggered changes.
- Added form reset handling with asynchronous sync.
- Restored original property descriptors on destroy to allow safe reinitialization.

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests. If removed, please explain why in additional notes.**
- [x] Added tests
- [x] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
**Provide any additional information or context related to this pull request.**
- This PR ensures safe reinitialization and prevents infinite loops caused by property setters triggering `onExternalChange`.
- Test coverage has been expanded to include property interception, form reset, and rerender behavior.
