### PR TITLE
fix(security): add HTML sanitization with allow-list for toggle labels 

### DIFF
--- a/src/main/ts/core/OptionResolver.ts
+++ b/src/main/ts/core/OptionResolver.ts
@@ -1,4 +1,4 @@
-import { isNumeric, sanitize } from "./Tools";
+import { isNumeric, sanitize, SanitizeMode } from "./Tools";
 import {
     UserOptions,
     ToggleOptions,
@@ -39,13 +39,13 @@ export class OptionResolver {
    * @param element HTMLInputElement to read
    * @param attrName Attribute name
    * @param options method options
-   * @param options.sanitized Flag to indicate if the attribute value needs to be sanitized (default: `true`)
+   * @param options.sanitized Flag to indicate if the sanitized mode needs to be used (default: `TEXT`)
    * @returns Sanitized attribute value or null
    */
-    private static getAttr (element: HTMLInputElement, attrName: string, opts?: {sanitized?:boolean}) {
-        const { sanitized = true } = opts ?? {};
+    private static getAttr (element: HTMLInputElement, attrName: string, opts?: {sanitized?:SanitizeMode}) {
+        const { sanitized = SanitizeMode.TEXT } = opts ?? {};
         const value = element.getAttribute(attrName);
-        return sanitized ? sanitize(value) : value;
+        return sanitize(value, { mode: sanitized }); ;
     }
 
     /**
@@ -54,7 +54,7 @@ export class OptionResolver {
    * @param attrName Attribute name
    * @param userValue Value provided by the user
    * @param defaultValue Default value if neither attribute nor user value exists
-   * @param sanitized Flag to indicate if the attribute value needs to be sanitized (default: {@code true})
+   * @param sanitized Flag to indicate if the sanitized mode needs to be used (default: `TEXT`)
    * @returns Final attribute value
    */
     private static getAttrOrDefault<T>(
@@ -62,9 +62,12 @@ export class OptionResolver {
         attrName: string,
         userValue: T | undefined,
         defaultValue: T,
-        sanitized:boolean=true
+        sanitized:SanitizeMode = SanitizeMode.TEXT
     ){
-        return OptionResolver.getAttr(element, attrName, {sanitized}) || userValue || defaultValue;
+        const sanitizedUserValue = typeof userValue === "string" ? sanitize(userValue as string, { mode: sanitized }) : userValue;
+        return OptionResolver.getAttr(element, attrName, {sanitized}) || 
+            sanitizedUserValue ||
+            defaultValue;
     }
 
     /**
@@ -72,17 +75,18 @@ export class OptionResolver {
    * @param element HTMLInputElement to read
    * @param attrName Attribute name
    * @param userValue Value provided by the user
-   * @param sanitized Flag to indicate if the attribute value needs to be sanitized (default: {@code true})
+   * @param sanitized Flag to indicate if the sanitized mode needs to be used (default: `TEXT`)
    * @returns Final attribute value or DeprecationConfig.value if not found
    */
     private static getAttrOrDeprecation<T>(
         element: HTMLInputElement,
         attrName: string,
         userValue: T,
-        sanitized:boolean=true
+        sanitized:SanitizeMode = SanitizeMode.TEXT
     ){
+        const sanitizedUserValue = typeof userValue === "string" ? sanitize(userValue as string, { mode: sanitized }) : userValue;
         return OptionResolver.getAttr(element, attrName, {sanitized}) ||
-            userValue ||
+            sanitizedUserValue ||
             DeprecationConfig.value;
     }
 
@@ -101,13 +105,13 @@ export class OptionResolver {
                 element,
                 "data-onlabel",
                 userOptions.onlabel,
-                false
+                SanitizeMode.HTML
             ),
             offlabel: this.getAttrOrDeprecation(
                 element,
                 "data-offlabel",
                 userOptions.offlabel,
-                false
+                SanitizeMode.HTML
             ),
             onstyle: this.getAttrOrDefault(
                 element,
@@ -227,16 +231,19 @@ class DeprecationConfig {
     currentOpt: OptionWithDeprecationRemap;
     deprecatedAttr: string;
     deprecatedOpt: OptionDeprecated;
+    mode: SanitizeMode
   }[] = [
             {
                 currentOpt: "onlabel",
                 deprecatedAttr: "data-on",
                 deprecatedOpt: "on",
+                mode: SanitizeMode.HTML 
             },
             {
                 currentOpt: "offlabel",
                 deprecatedAttr: "data-off",
                 deprecatedOpt: "off",
+                mode: SanitizeMode.HTML
             },
         ];
 
@@ -252,10 +259,11 @@ class DeprecationConfig {
         userOptions: UserOptions
     ): void {
         this.deprecatedOptions.forEach(
-            ({ currentOpt, deprecatedAttr, deprecatedOpt }) => {
+            ({ currentOpt, deprecatedAttr, deprecatedOpt, mode }) => {
                 if (options[currentOpt] === DeprecationConfig.value) {
                     const deprecatedAttrSanitized = sanitize(
-                        element.getAttribute(deprecatedAttr)
+                        element.getAttribute(deprecatedAttr),
+                        {mode}
                     );
                     if (deprecatedAttrSanitized) {
                         this.log(

--- a/src/main/ts/core/Tools.ts
+++ b/src/main/ts/core/Tools.ts
@@ -95,7 +95,9 @@ function sanitizeHTML(
                     // Additional security for specific attributes
                     if (attrName === "src" || attrName === "href") {
                         const value = attr.value.toLowerCase();
-                        if (value.startsWith("javascript:") || value.startsWith("data:") && !value.startsWith("data:image/")) {
+                        if (value.startsWith("javascript:")
+                            || value.startsWith("vbscript:")
+                            || (value.startsWith("data:") && !value.startsWith("data:image/"))) {
                             element.removeAttribute(attr.name);
                         }
                     }

--- a/src/main/ts/core/Tools.ts
+++ b/src/main/ts/core/Tools.ts
@@ -1,6 +1,40 @@
-export function sanitize(text: string | null): string | null {
-    if (!text) return text;
+export type SanitizeOptions = {
+    mode:SanitizeMode;
+}
+export enum SanitizeMode{
+    HTML = "HTML",
+    TEXT = "TEXT"
+}
 
+
+/**
+ * Sanitizes a given text string according to the provided options.
+ * If the input text is null, it will return null.
+ * If the input text is not null, it will sanitize the text according to the provided mode.
+ * If the mode is HTML, it will sanitize the text using the sanitizeHTML function.
+ * If the mode is TEXT, it will sanitize the text using the sanitizeText function.
+ * @param text The text string to sanitize.
+ * @param opts The options to use for sanitizing the text.
+ * @return The sanitized text string, or null if the input text was null.
+ */
+export function sanitize(text: string | null, opts: SanitizeOptions): string | null{
+    if (!text) return text;
+    switch (opts.mode) {
+    case SanitizeMode.HTML:
+        return sanitizeHTML(text);
+    
+    case SanitizeMode.TEXT:
+        return sanitizeText(text);
+    }
+}
+
+/**
+ * Sanitizes a given text string, replacing special characters with their HTML entities.
+ * If the input text is null, it will return null.
+ * @param text The text string to sanitize.
+ * @return The sanitized text string, or null if the input text was null.
+ */
+function sanitizeText(text: string ): string {
     const map: Record<string, string> = {
         "&": "&amp;",
         "<": "&lt;",
@@ -11,6 +45,77 @@ export function sanitize(text: string | null): string | null {
     };
     // Using replace with regex for single-pass character mapping compatible with ES5
     return text.replace(/[&<>"'/]/g, (m) => map[m]);
+}
+
+/**
+ * Sanitizes HTML content using an allow-list approach to prevent XSS attacks.
+ * 
+ * @param html The HTML string to sanitize
+ * @param options Configuration options for allowed tags and attributes
+ * @returns Sanitized HTML string
+ */
+function sanitizeHTML(
+    html: string
+): string {    
+    const config = {
+        allowedTags: ["b", "i", "strong", "em", "span", "small", "sup", "sub", "img"],
+        allowedAttributes: ["class", "style", "src", "alt", "title", "data-*"]
+    };
+    
+    // Implementation using DOMParser for browser compatibility
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    
+    const sanitizeNode = (node: Node): void => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+            const element = node as HTMLElement;
+            const tagName = element.tagName.toLowerCase();
+            
+            // Remove disallowed tags
+            if (!config.allowedTags.includes(tagName)) {
+                // Replace disallowed element with its text content
+                const fragment = document.createDocumentFragment();
+                Array.from(element.childNodes).forEach(child => {
+                    fragment.appendChild(child.cloneNode(true));
+                });
+                element.parentNode?.replaceChild(fragment, element);
+                return;
+            }
+            
+            // Remove disallowed attributes
+            Array.from(element.attributes).forEach(attr => {
+                const attrName = attr.name.toLowerCase();
+                const isAllowed = config.allowedAttributes.some(allowed => 
+                    allowed.endsWith("*") ? attrName.startsWith(allowed.slice(0, -1)) : attrName === allowed
+                );
+                
+                if (!isAllowed) {
+                    element.removeAttribute(attr.name);
+                } else {
+                    // Additional security for specific attributes
+                    if (attrName === "src" || attrName === "href") {
+                        const value = attr.value.toLowerCase();
+                        if (value.startsWith("javascript:") || value.startsWith("data:") && !value.startsWith("data:image/")) {
+                            element.removeAttribute(attr.name);
+                        }
+                    }
+                }
+            });
+            
+            // Recursively sanitize children
+            const children = Array.from(element.childNodes);
+            children.forEach(sanitizeNode);
+        } else if (node.nodeType === Node.TEXT_NODE) {
+            // Text nodes are safe, keep them as is
+            return;
+        }
+    };
+    
+    // Sanitize all nodes in the document body
+    const bodyChildren = Array.from(doc.body.childNodes);
+    bodyChildren.forEach(sanitizeNode);
+    
+    return doc.body.innerHTML;
 }
 
 /**

--- a/src/main/ts/core/Tools.ts
+++ b/src/main/ts/core/Tools.ts
@@ -65,8 +65,27 @@ function sanitizeHTML(
     // Implementation using DOMParser for browser compatibility
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
+        
+    // Sanitize all nodes in the document body
+    const bodyChildren = Array.from(doc.body.childNodes);
+    bodyChildren.forEach((node) => sanitizeNode(node, config));
     
-    const sanitizeNode = (node: Node): void => {
+    return doc.body.innerHTML;
+}
+
+/**
+ * Sanitizes a single node in the document tree.
+ * 
+ * For element nodes, it removes disallowed tags and attributes.
+ * For text nodes, it keeps them as is.
+ * 
+ * Recursively sanitizes all children of an element node.
+ * 
+ * @param node The node to sanitize
+ * @param config Configuration options for allowed tags and attributes
+ */
+function sanitizeNode (node: Node, config: { allowedTags: string[], allowedAttributes: string[] }): void {
+    const sanitizeNodeRecursive = (node: Node) => {
         if (node.nodeType === Node.ELEMENT_NODE) {
             const element = node as HTMLElement;
             const tagName = element.tagName.toLowerCase();
@@ -89,36 +108,45 @@ function sanitizeHTML(
                     allowed.endsWith("*") ? attrName.startsWith(allowed.slice(0, -1)) : attrName === allowed
                 );
                 
-                if (!isAllowed) {
-                    element.removeAttribute(attr.name);
+                if (isAllowed) {
+                    sanitizeAllowedAttr(element, attr, attrName);
                 } else {
-                    // Additional security for specific attributes
-                    if (attrName === "src" || attrName === "href") {
-                        const value = attr.value.toLowerCase();
-                        if (value.startsWith("javascript:")
-                            || value.startsWith("vbscript:")
-                            || (value.startsWith("data:") && !value.startsWith("data:image/"))) {
-                            element.removeAttribute(attr.name);
-                        }
-                    }
+                    element.removeAttribute(attr.name);
                 }
             });
             
             // Recursively sanitize children
             const children = Array.from(element.childNodes);
-            children.forEach(sanitizeNode);
+            children.forEach(sanitizeNodeRecursive);
         } else if (node.nodeType === Node.TEXT_NODE) {
             // Text nodes are safe, keep them as is
             return;
         }
     };
-    
-    // Sanitize all nodes in the document body
-    const bodyChildren = Array.from(doc.body.childNodes);
-    bodyChildren.forEach(sanitizeNode);
-    
-    return doc.body.innerHTML;
+    sanitizeNodeRecursive(node);
 }
+
+/**
+ * Sanitizes an allowed attribute by removing it if its value is a dangerous protocol.
+ * Only works for "src" and "href" attributes.
+ * @param element The element to check for the attribute.
+ * @param attr The attribute to check the value of.
+ * @param attrName The name of the attribute to check (either "src" or "href").
+ */
+function sanitizeAllowedAttr (element: HTMLElement, attr: Attr, attrName: string): void {
+    if (attrName !== "src" && attrName !== "href") return;
+    
+    const value = attr.value.toLowerCase();
+    
+    // sonar typescript:S1523 - This is security detection, not execution
+    const isDangerousProtocol = value.startsWith("javascript:") ||
+                                value.startsWith("vbscript:") ||
+                                (value.startsWith("data:") && !value.startsWith("data:image/"));
+    
+    if (isDangerousProtocol) {
+        element.removeAttribute(attr.name);
+    }
+};
 
 /**
  * Checks if the given string is a valid numeric value.

--- a/src/test/ts/core/Tools.test.ts
+++ b/src/test/ts/core/Tools.test.ts
@@ -1,52 +1,121 @@
-import { isNumeric, sanitize } from "../../../main/ts/core/Tools";
+import { isNumeric, sanitize, SanitizeMode } from "../../../main/ts/core/Tools";
 
 describe("sanitize", () => {
     it("returns null when input is null", () => {
-        expect(sanitize(null)).toBeNull();
+        expect(sanitize(null, { mode: SanitizeMode.TEXT })).toBeNull();
+        expect(sanitize(null, { mode: SanitizeMode.HTML })).toBeNull();
+    });
+    it("handles empty string", () => {
+        expect(sanitize("", { mode: SanitizeMode.TEXT })).toBe("");
+        expect(sanitize("", { mode: SanitizeMode.HTML })).toBe("");
     });
 
-    it("returns empty string when input is empty", () => {
-        expect(sanitize("")).toBe("");
+    describe("text mode", () => {
+        it("returns empty string when input is empty", () => {
+            expect(sanitize("", { mode: SanitizeMode.TEXT })).toBe("");
+        });
+
+        it("does not modify a safe string", () => {
+            const text = "Hello world 123";
+            expect(sanitize(text, { mode: SanitizeMode.TEXT })).toBe(text);
+        });
+
+        it("escapes ampersand", () => {
+            expect(sanitize("&", { mode: SanitizeMode.TEXT })).toBe("&amp;");
+        });
+
+        it("escapes less than", () => {
+            expect(sanitize("<", { mode: SanitizeMode.TEXT })).toBe("&lt;");
+        });
+
+        it("escapes greater than", () => {
+            expect(sanitize(">", { mode: SanitizeMode.TEXT })).toBe("&gt;");
+        });
+
+        it("escapes double quotes", () => {
+            expect(sanitize('"', { mode: SanitizeMode.TEXT })).toBe("&quot;");
+        });
+
+        it("escapes single quotes", () => {
+            expect(sanitize("'", { mode: SanitizeMode.TEXT })).toBe("&#39;");
+        });
+
+        it("escapes slash", () => {
+            expect(sanitize("/", { mode: SanitizeMode.TEXT })).toBe("&#x2F;");
+        });
+
+        it("escapes multiple characters in the same string", () => {
+            const text = "<script>alert(\"xss\")</script>";
+            expect(sanitize(text, { mode: SanitizeMode.TEXT })).toBe(
+                "&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;"
+            );
+        });
+
+        it("escapes characters appearing multiple times", () => {
+            expect(sanitize("&&&&", { mode: SanitizeMode.TEXT })).toBe("&amp;&amp;&amp;&amp;");
+        });
     });
 
-    it("does not modify a safe string", () => {
-        const text = "Hello world 123";
-        expect(sanitize(text)).toBe(text);
-    });
+    describe("html mode", () => {
+        it("removes script tags", () => {
+            const input = '<script>alert("xss")</script>Safe text';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("Safe text");
+        });
 
-    it("escapes ampersand", () => {
-        expect(sanitize("&")).toBe("&amp;");
-    });
+        it("removes script tags with attributes", () => {
+            const input = '<script type="text/javascript">alert("xss")</script>Safe';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("Safe");
+        });
 
-    it("escapes less than", () => {
-        expect(sanitize("<")).toBe("&lt;");
-    });
+        it("allows safe tags", () => {
+            const input = "<b>bold</b> and <i>italic</i>";
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("<b>bold</b> and <i>italic</i>");
+        });
 
-    it("escapes greater than", () => {
-        expect(sanitize(">")).toBe("&gt;");
-    });
+        it("removes dangerous attributes", () => {
+            const input = '<span onclick="alert(1)" onmouseover="evil()">click</span>';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("<span>click</span>");
+        });
 
-    it("escapes double quotes", () => {
-        expect(sanitize('"')).toBe("&quot;");
-    });
+        it("allows safe attributes", () => {
+            const input = '<span class="my-class" style="color: red;">styled</span>';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe('<span class="my-class" style="color: red;">styled</span>');
+        });
 
-    it("escapes single quotes", () => {
-        expect(sanitize("'")).toBe("&#39;");
-    });
+        it("handles img tags safely", () => {
+            const input = '<img src="image.jpg" alt="image" onerror="alert(1)">';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe('<img src="image.jpg" alt="image">');
+        });
 
-    it("escapes slash", () => {
-        expect(sanitize("/")).toBe("&#x2F;");
-    });
+        it("removes javascript: protocol in href/src", () => {
+            const input = '<a href="javascript:alert(1)">click</a><img src="javascript:evil()">';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("click<img>");
+        });
 
-    it("escapes multiple characters in the same string", () => {
-        const text = "<script>alert(\"xss\")</script>";
-        expect(sanitize(text)).toBe(
-            "&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;"
-        );
-    });
+        it("allows data:image/ protocol for images", () => {
+            const input = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe('<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">');
+        });
 
-    it("escapes characters appearing multiple times", () => {
-        expect(sanitize("&&&&")).toBe("&amp;&amp;&amp;&amp;");
+        it("removes dangerous data: protocol", () => {
+            const input = '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">';
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("<img>");
+        });
+
+        it("handles nested elements correctly", () => {
+            const input = "<div><b>bold <i>italic</i></b> text</div>";
+            const result = sanitize(input, { mode: SanitizeMode.HTML });
+            expect(result).toBe("<b>bold <i>italic</i></b> text");
+        });
     });
 });
 

--- a/src/test/ts/core/Tools.test.ts
+++ b/src/test/ts/core/Tools.test.ts
@@ -20,29 +20,21 @@ describe("sanitize", () => {
             expect(sanitize(text, { mode: SanitizeMode.TEXT })).toBe(text);
         });
 
-        it("escapes ampersand", () => {
-            expect(sanitize("&", { mode: SanitizeMode.TEXT })).toBe("&amp;");
-        });
+        const escapeCases = [
+            { input: "&", expected: "&amp;", description: "ampersand" },
+            { input: "<", expected: "&lt;", description: "less than" },
+            { input: ">", expected: "&gt;", description: "greater than" },
+            { input: '"', expected: "&quot;", description: "double quotes" },
+            { input: "'", expected: "&#39;", description: "single quotes" },
+            { input: "/", expected: "&#x2F;", description: "slash" },
+        ];
 
-        it("escapes less than", () => {
-            expect(sanitize("<", { mode: SanitizeMode.TEXT })).toBe("&lt;");
-        });
-
-        it("escapes greater than", () => {
-            expect(sanitize(">", { mode: SanitizeMode.TEXT })).toBe("&gt;");
-        });
-
-        it("escapes double quotes", () => {
-            expect(sanitize('"', { mode: SanitizeMode.TEXT })).toBe("&quot;");
-        });
-
-        it("escapes single quotes", () => {
-            expect(sanitize("'", { mode: SanitizeMode.TEXT })).toBe("&#39;");
-        });
-
-        it("escapes slash", () => {
-            expect(sanitize("/", { mode: SanitizeMode.TEXT })).toBe("&#x2F;");
-        });
+        it.each(escapeCases)(
+            "escapes $description",
+            ({ input, expected }) => {
+                expect(sanitize(input, { mode: SanitizeMode.TEXT })).toBe(expected);
+            }
+        );
 
         it("escapes multiple characters in the same string", () => {
             const text = "<script>alert(\"xss\")</script>";
@@ -57,65 +49,71 @@ describe("sanitize", () => {
     });
 
     describe("html mode", () => {
-        it("removes script tags", () => {
-            const input = '<script>alert("xss")</script>Safe text';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("Safe text");
-        });
-
-        it("removes script tags with attributes", () => {
-            const input = '<script type="text/javascript">alert("xss")</script>Safe';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("Safe");
-        });
-
-        it("allows safe tags", () => {
-            const input = "<b>bold</b> and <i>italic</i>";
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("<b>bold</b> and <i>italic</i>");
-        });
-
-        it("removes dangerous attributes", () => {
-            const input = '<span onclick="alert(1)" onmouseover="evil()">click</span>';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("<span>click</span>");
-        });
-
-        it("allows safe attributes", () => {
-            const input = '<span class="my-class" style="color: red;">styled</span>';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe('<span class="my-class" style="color: red;">styled</span>');
-        });
-
-        it("handles img tags safely", () => {
-            const input = '<img src="image.jpg" alt="image" onerror="alert(1)">';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe('<img src="image.jpg" alt="image">');
-        });
-
-        it("removes javascript: protocol in href/src", () => {
-            const input = '<a href="javascript:alert(1)">click</a><img src="javascript:evil()">';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("click<img>");
-        });
-
-        it("allows data:image/ protocol for images", () => {
-            const input = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe('<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">');
-        });
-
-        it("removes dangerous data: protocol", () => {
-            const input = '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">';
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("<img>");
-        });
-
-        it("handles nested elements correctly", () => {
-            const input = "<div><b>bold <i>italic</i></b> text</div>";
-            const result = sanitize(input, { mode: SanitizeMode.HTML });
-            expect(result).toBe("<b>bold <i>italic</i></b> text");
-        });
+        const htmlTestCases = [
+            {
+                description: "removes script tags",
+                input: '<script>alert("xss")</script>Safe text',
+                expected: "Safe text"
+            },
+            {
+                description: "removes script tags with attributes",
+                input: '<script type="text/javascript">alert("xss")</script>Safe',
+                expected: "Safe"
+            },
+            {
+                description: "allows safe tags",
+                input: "<b>bold</b> and <i>italic</i>",
+                expected: "<b>bold</b> and <i>italic</i>"
+            },
+            {
+                description: "removes dangerous attributes",
+                input: '<span onclick="alert(1)" onmouseover="evil()">click</span>',
+                expected: "<span>click</span>"
+            },
+            {
+                description: "allows safe attributes",
+                input: '<span class="my-class" style="color: red;">styled</span>',
+                expected: '<span class="my-class" style="color: red;">styled</span>'
+            },
+            {
+                description: "handles img tags safely",
+                input: '<img src="image.jpg" alt="image" onerror="alert(1)">',
+                expected: '<img src="image.jpg" alt="image">'
+            },
+            {
+                description: "removes javascript: protocol in href/src",
+                input: '<a href="javascript:alert(1)">click</a><img src="javascript:evil()">',
+                expected: "click<img>"
+            },
+            {
+                description: "removes vbscript: protocol in href/src",
+                input: '<a href="vbscript:alert(1)">click</a><img src="vbscript:evil()">',
+                expected: "click<img>"
+            },
+            {
+                description: "allows data:image/ protocol for images",
+                input: '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">',
+                expected: '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA">'
+            },
+            {
+                description: "removes dangerous data: protocol",
+                input: '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCg1KTwvc2NyaXB0Pg==">',
+                expected: "<img>"
+            },
+            {
+                description: "handles nested elements correctly",
+                input: "<div><b>bold <i>italic</i></b> text</div>",
+                expected: "<b>bold <i>italic</i></b> text"
+            },
+        ];
+        
+        it.each(htmlTestCases)(
+            "$description",
+            ({ input, expected }) => {
+                const result = sanitize(input, { mode: SanitizeMode.HTML });
+                expect(result).toBe(expected);
+            }
+        );
     });
 });
 


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [X] Bug Fix (Fixes #257)
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
Implement secure HTML sanitization using allow-list approach to prevent XSS
vulnerabilities while allowing safe HTML in toggle labels.

Key changes:
- Add sanitizeHTML() function with allow-list of tags and attributes
- Extend sanitize() to support TEXT and HTML modes
- Apply HTML sanitization to toggle labels (data-onlabel/data-offlabel)
- Maintain TEXT sanitization for other attributes for safety
- Add comprehensive unit tests for XSS prevention

Allows safe HTML formatting (bold, italic, icons) while blocking scripts,
event handlers, and dangerous protocols. Users can now safely include
icons and formatted text in toggle labels.

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests. If removed, please explain why in additional notes.**
- [X] Added tests
- [ ] Modified tests
- [x] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
**Provide any additional information or context related to this pull request.**
- Security approach: Allow-list (whitelist) instead of block-list for better XSS protection
- Sanitization centralized in OptionResolver for consistency and maintainability
- Performance impact minimal (only during initialization)
- Backward compatible: Existing HTML label usage continues to work safely
- Fixes security vulnerability in HTML label rendering

---

## Pull Request Checklist
- [X] Code adheres to the project's coding style guide.
- [X] All tests are passing.
- [X] The pull request description is complete.
- [X] Documentation is updated if needed.