### PR TITLE
fix: make keyboard event handler non-passive and prevent default space/enter

### DIFF
--- a/src/main/ts/BootstrapToggle.ts
+++ b/src/main/ts/BootstrapToggle.ts
@@ -270,14 +270,12 @@ export class Toggle {
    * Binds a keydown event listener to the root element of the toggle.
    * The event listener is responsible for handling keydown events
    * and triggering the toggle's state change when a keydown event occurs.
-   * The event listener is bound with the passive option, which means that it will not block
-   * other event listeners from being triggered.
    */
     private bindKeyboardEventListener() {
         this.domBuilder.root.addEventListener(
             "keydown",
             this.handlerKeyboardEvent,
-            { passive: true }
+            { passive: false }
         );
     }
 
@@ -296,6 +294,7 @@ export class Toggle {
     }
     private readonly handlerKeyboardEvent = (e: KeyboardEvent) => {
         if (e.key === " " || e.key === "Enter") {
+            e.preventDefault();
             this.apply(ToggleActionType.NEXT);
         }
     };


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

### Description
This PR fixes a bug where pressing the Space or Enter key on a toggle element could cause unintended scrolling or form submission. The keyboard event listener has been changed from `passive: true` to `passive: false` to allow `preventDefault()` to be called, effectively preventing the default browser behavior for these keys.

Fixes #287  
Reported by @palcarazm

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests. If removed, please explain why in additional notes.**
- [ ] Modified tests
- [ ] Added tests
- [ ] Fixed tests
- [ ] Removed tests

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
No additional notes.