### PR TITLE
feat: add silent parameter support to enable, disable and readonly methods

### DIFF
--- a/src/main/js/index.jquery.js
+++ b/src/main/js/index.jquery.js
@@ -33,15 +33,15 @@ import { ToggleMethods } from "./types/ToggleMethods";
                     break;
                 case ToggleMethods.ENABLE:
                 case ToggleMethods.enable:
-                    _bsToggle.enable();
+                    _bsToggle.enable(silent);
                     break;
                 case ToggleMethods.DISABLE:
                 case ToggleMethods.disable:
-                    _bsToggle.disable();
+                    _bsToggle.disable(silent);
                     break;
                 case ToggleMethods.READONLY:
                 case ToggleMethods.readonly:
-                    _bsToggle.readonly();
+                    _bsToggle.readonly(silent);
                     break;
                 case ToggleMethods.DESTROY:
                 case ToggleMethods.destroy:

--- a/src/main/ts/BootstrapToggle.ts
+++ b/src/main/ts/BootstrapToggle.ts
@@ -412,29 +412,32 @@ export class Toggle {
    * Enables the toggle.
    * If the toggle is currently disabled, this method will set the toggle state to enabled.
    * If the silent parameter is false, this method will also trigger the change event.
+   * @param {boolean} silent A boolean indicating whether to trigger the change event after applying the action.
    * @returns void
    */
-    enable() {
-        this.apply(ToggleActionType.ENABLE);
+    enable(silent = false) {
+        this.apply(ToggleActionType.ENABLE, silent);
     }
 
     /**
    * Disables the toggle.
    * If the toggle is currently enabled, this method will set the toggle state to disabled.
    * If the silent parameter is false, this method will also trigger the change event.
+   * @param {boolean} silent A boolean indicating whether to trigger the change event after applying the action.
    */
-    disable() {
-        this.apply(ToggleActionType.DISABLE);
+    disable(silent = false) {
+        this.apply(ToggleActionType.DISABLE, silent);
     }
 
     /**
    * Sets the toggle state to readonly.
    * If the toggle is currently disabled or enabled, this method will set the toggle state to readonly.
    * If the silent parameter is false, this method will also trigger the change event.
+   * @param {boolean} silent A boolean indicating whether to trigger the change event after applying the action.
    * @returns void
    */
-    readonly() {
-        this.apply(ToggleActionType.READONLY);
+    readonly(silent = false) {
+        this.apply(ToggleActionType.READONLY, silent);
     }
 
     /**

--- a/src/main/ts/index.ecmas.ts
+++ b/src/main/ts/index.ecmas.ts
@@ -31,13 +31,13 @@ import { ToggleMethods } from "./types/ToggleMethods";
                 return _bsToggle.determinate(silent);
             case ToggleMethods.ENABLE:
             case ToggleMethods.enable:
-                return _bsToggle.enable();
+                return _bsToggle.enable(silent);
             case ToggleMethods.DISABLE:
             case ToggleMethods.disable:
-                return _bsToggle.disable();
+                return _bsToggle.disable(silent);
             case ToggleMethods.READONLY:
             case ToggleMethods.readonly:
-                return _bsToggle.readonly();
+                return _bsToggle.readonly(silent);
             case ToggleMethods.DESTROY:
             case ToggleMethods.destroy:
                 return _bsToggle.destroy();

--- a/src/test/ts/BootstrapToggle.test.ts
+++ b/src/test/ts/BootstrapToggle.test.ts
@@ -595,25 +595,34 @@ describe("Toggle", () => {
             expect(apply).toHaveBeenCalledWith(ToggleActionType.INDETERMINATE, true);
         });
 
-        it("enable()", () => {
+        it("enable(silent=false)", () => {
             const toggle = new Toggle(input, {});
 
             toggle.enable();
-            expect(apply).toHaveBeenCalledWith(ToggleActionType.ENABLE);
+            expect(apply).toHaveBeenCalledWith(ToggleActionType.ENABLE, false);
+
+            toggle.enable(true);
+            expect(apply).toHaveBeenCalledWith(ToggleActionType.ENABLE, true);
         });
 
-        it("disable()", () => {
+        it("disable(silent=false)", () => {
             const toggle = new Toggle(input, {});
 
             toggle.disable();
-            expect(apply).toHaveBeenCalledWith(ToggleActionType.DISABLE);
+            expect(apply).toHaveBeenCalledWith(ToggleActionType.DISABLE, false);
+
+            toggle.disable(true);
+            expect(apply).toHaveBeenCalledWith(ToggleActionType.DISABLE, true);
         });
 
-        it("readonly()", () => {
+        it("readonly(silent=false)", () => {
             const toggle = new Toggle(input, {});
 
             toggle.readonly();
-            expect(apply).toHaveBeenCalledWith(ToggleActionType.READONLY);
+            expect(apply).toHaveBeenCalledWith(ToggleActionType.READONLY, false);
+
+            toggle.readonly(true);
+            expect(apply).toHaveBeenCalledWith(ToggleActionType.READONLY, true);
         });
     });
 


### PR DESCRIPTION
## Pull Request

### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
This PR adds support for the `silent` parameter in the `enable()`, `disable()`, and `readonly()` methods, allowing users to suppress change events when programmatically modifying the toggle state. The parameter is now properly passed through both jQuery and ECMAS interfaces, and the TypeScript method signatures have been updated with appropriate JSDoc comments.

Fixes #289  
Reported by @palcarazm

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests. If removed, please explain why in additional notes.**
- [x] Modified tests
- [ ] Added tests
- [ ] Fixed tests
- [ ] Removed tests

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
No breaking changes introduced. The `silent` parameter is optional and defaults to `false` to maintain backward compatibility.

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.
