### PR TITLE
fix: export published css and js assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
       "types": "./dist/bootstrap5-toggle.d.ts",
       "import": "./dist/bootstrap5-toggle.mjs",
       "require": "./dist/bootstrap5-toggle.cjs"
-    }
+    },
+    "./css/*": "./css/*",
+    "./js/*": "./js/*"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
Fixes #328.

package.json publishes the css/* and js/* asset directories, and prior releases allowed consumers to import paths such as:

- ootstrap5-toggle/js/bootstrap5-toggle.ecmas.js
- ootstrap5-toggle/css/bootstrap5-toggle.css

After the package added an exports map, those already-published files became blocked by Node/package-manager resolution with ERR_PACKAGE_PATH_NOT_EXPORTED. This adds matching ./css/* and ./js/* subpath export patterns so the published assets remain addressable while the root JS/type entrypoints stay unchanged.

Verification:
- Reproduced ootstrap5-toggle@5.3.3 failing to resolve both reported subpaths with ERR_PACKAGE_PATH_NOT_EXPORTED.
- Ran 
pm install --ignore-scripts --no-audit --no-fund.
- Ran 
pm run build.
- Ran 
pm run test:unit (157 passed).
- Ran 
pm pack --ignore-scripts, installed the tarball in a clean consumer project, and verified import.meta.resolve() succeeds for the reported JS/CSS paths plus minified/jquery assets.