### PR TITLE
v5.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ See EOL for each version in [Security Policy Page](https://github.com/palcarazm/
 
 ```html
 <link
-  href="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.0/css/bootstrap5-toggle.min.css"
+  href="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.1/css/bootstrap5-toggle.min.css"
   rel="stylesheet" />
-<script src="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.0/js/bootstrap5-toggle.ecmas.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.1/js/bootstrap5-toggle.ecmas.min.js"></script>
 ```
 
 ### jQuery Interface
 
 ```html
 <link
-  href="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.0/css/bootstrap5-toggle.min.css"
+  href="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.1/css/bootstrap5-toggle.min.css"
   rel="stylesheet" />
-<script src="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.0/js/bootstrap5-toggle.jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap5-toggle@5.4.1/js/bootstrap5-toggle.jquery.min.js"></script>
 ```
 
 ## Download
@@ -89,13 +89,13 @@ See EOL for each version in [Security Policy Page](https://github.com/palcarazm/
 [![NPM Badge](https://img.shields.io/npm/dm/bootstrap5-toggle?logo=npm)](https://www.npmjs.com/package/bootstrap5-toggle)
 
 ```ksh
-npm install bootstrap5-toggle@5.4.0
+npm install bootstrap5-toggle@5.4.1
 ```
 
 ## Yarn
 
 ```ksh
-yarn add bootstrap5-toggle@5.4.0
+yarn add bootstrap5-toggle@5.4.1
 ```
 
 # Usage

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/fontawesome-free": "7.2.0",
     "@highlightjs/cdn-assets": "11.11.1",
     "bootstrap": "5.3.8",
-    "bootstrap5-toggle": "5.4.0",
+    "bootstrap5-toggle": "5.4.1",
     "bs-darkmode-toggle": "1.0.0",
     "highlightjs-badge": "0.1.9",
     "jquery": "4.0.0"

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,25 +1,26 @@
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>/src/test/setup/dom.setup.ts", "<rootDir>/src/test/setup/events.setup.ts"],
-  transform: {
-      "^.+\\.ts$": ["ts-jest", {
-          tsconfig: "tsconfig.test.json",
-      }],
-  },
-  collectCoverageFrom: [
-      "src/main/ts/**/*.ts",
-      "!**/index*.ts",
-      "!src/main/ts/types/**/*.ts",
-  ],
-  coverageThreshold: {
-      global: {
-          statements: 80,
-          branches: 80,
-          functions: 80,
-          lines: 80,
-      },
-  },
-  coverageDirectory: "coverage",
-  reporters: [["github-actions", {silent: false}], "summary"],
+    preset: "ts-jest",
+    testEnvironment: "jsdom",
+    setupFilesAfterEnv: ["<rootDir>/src/test/setup/dom.setup.ts", "<rootDir>/src/test/setup/events.setup.ts"],
+    testMatch: ["<rootDir>/src/test/ts/**/*.test.ts"],
+    transform: {
+        "^.+\\.ts$": ["ts-jest", {
+            tsconfig: "tsconfig.test.json",
+        }],
+    },
+    collectCoverageFrom: [
+        "src/main/ts/**/*.ts",
+        "!**/index*.ts",
+        "!src/main/ts/types/**/*.ts",
+    ],
+    coverageThreshold: {
+        global: {
+            statements: 80,
+            branches: 80,
+            functions: 80,
+            lines: 80,
+        },
+    },
+    coverageDirectory: "coverage",
+    reporters: [["github-actions", { silent: false }], "summary"],
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   "module": "dist/bootstrap5-toggle.mjs",
   "types": "dist/bootstrap5-toggle.d.ts",
   "typings": "dist/bootstrap5-toggle.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "css/*.css",
+    "js/*.js"
+  ],
   "files": [
     "css/*",
     "js/*",
@@ -49,8 +52,8 @@
     "postversion": "git push --follow-tags",
     "prepack": "npm run build && npm run version:update && doctoc README.md --github",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:e2e": "cypress run --headless",
     "test:unit": "jest --coverage",
+    "test:e2e": "cypress run --headless",
     "lint": "eslint ./src",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap5-toggle",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "type": "module",
   "author": {
     "name": "Pablo Alcaraz Martínez",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.organization=palcarazm
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPath=tsconfig.json
 
-sonar.coverage.exclusions=docs/**,test/**,cypress/**,src/test/**,src/main/js/**,src/main/ts/**/index*.ts,src/main/ts/types/**
+sonar.coverage.exclusions=docs/**,test/**,cypress/**,src/test/**,src/main/js/**,src/main/ts/**/index*.ts,src/main/ts/types/**,*.config.js,*.config.mjs,*.config.cjs
 sonar.cpd.exclusions=test/**,cypress/**,src/test/**


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation

---

### Description

**Bug Fix: Tree-shaking removes DOM-initializing side-effects (#334)**

This PR fixes an issue where the DOM-initializing side-effect that registers `bootstrapToggle` on `HTMLInputElement.prototype` was being removed by tree-shaking in ESM/bundler environments (Vite, Webpack, Rollup, etc.).

**The Problem**
When importing the full bundle via `import 'bootstrap5-toggle/js/bootstrap5-toggle.ecmas.js'`, bundlers would tree-shake the side-effect that patches `HTMLInputElement.prototype.bootstrapToggle`. This resulted in:

```
TypeError: element.bootstrapToggle is not a function
```

The workaround of `new BootstrapToggle(element)` still worked, confirming that only the prototype-patching side-effect was being eliminated.

**The Fix**
- **Updated `sideEffects` in `package.json`** to mark CSS and JS files as side-effectful:
   ```json
   "sideEffects": [
     "css/*.css",
     "js/*.js"
   ]
   ```

**Related Issues**
- Fixes #334

---

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [ ] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests

---

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

**Note:** No documentation updates included in this PR. The fix is internal and does not change the public API.

---

### Additional Notes

**Breaking Changes:** None - this is a patch release.

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide
- [x] All tests are passing
- [x] The pull request description is complete
- [x] Documentation is updated if needed (not applicable for this change)
